### PR TITLE
Initial commit of motion interchange format

### DIFF
--- a/examples/apps/Catalog/MotionInterchangeCatalog.xcodeproj/project.pbxproj
+++ b/examples/apps/Catalog/MotionInterchangeCatalog.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		663ED7C71EDF1F0C0096B2A9 /* HexColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663ED7C21EDF1F0C0096B2A9 /* HexColor.swift */; };
 		663ED7C81EDF1F0C0096B2A9 /* Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663ED7C31EDF1F0C0096B2A9 /* Layout.swift */; };
 		663ED7C91EDF1F0C0096B2A9 /* ModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663ED7C41EDF1F0C0096B2A9 /* ModalViewController.swift */; };
+		663ED8011EE628BA0096B2A9 /* MDMMotionCurveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 663ED8001EE628BA0096B2A9 /* MDMMotionCurveTests.swift */; };
+		663ED8031EE6299A0096B2A9 /* MDMMotionCurveTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 663ED8021EE6299A0096B2A9 /* MDMMotionCurveTests.m */; };
 		666FAA841D384A6B000363DA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 666FAA831D384A6B000363DA /* AppDelegate.swift */; };
 		666FAA8B1D384A6B000363DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8A1D384A6B000363DA /* Assets.xcassets */; };
 		666FAA8E1D384A6B000363DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 666FAA8C1D384A6B000363DA /* LaunchScreen.storyboard */; };
@@ -49,6 +51,8 @@
 		663ED7C21EDF1F0C0096B2A9 /* HexColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HexColor.swift; sourceTree = "<group>"; };
 		663ED7C31EDF1F0C0096B2A9 /* Layout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Layout.swift; sourceTree = "<group>"; };
 		663ED7C41EDF1F0C0096B2A9 /* ModalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ModalViewController.swift; sourceTree = "<group>"; };
+		663ED8001EE628BA0096B2A9 /* MDMMotionCurveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MDMMotionCurveTests.swift; sourceTree = "<group>"; };
+		663ED8021EE6299A0096B2A9 /* MDMMotionCurveTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMMotionCurveTests.m; sourceTree = "<group>"; };
 		666FAA801D384A6B000363DA /* MotionInterchangeCatalog.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MotionInterchangeCatalog.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		666FAA831D384A6B000363DA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = Catalog/AppDelegate.swift; sourceTree = "<group>"; };
 		666FAA8A1D384A6B000363DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -156,6 +160,8 @@
 		666FAA971D384A6B000363DA /* tests */ = {
 			isa = PBXGroup;
 			children = (
+				663ED8001EE628BA0096B2A9 /* MDMMotionCurveTests.swift */,
+				663ED8021EE6299A0096B2A9 /* MDMMotionCurveTests.m */,
 			);
 			name = tests;
 			path = ../../../tests/unit;
@@ -455,6 +461,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				663ED8031EE6299A0096B2A9 /* MDMMotionCurveTests.m in Sources */,
+				663ED8011EE628BA0096B2A9 /* MDMMotionCurveTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/MDMMotionCurve.h
+++ b/src/MDMMotionCurve.h
@@ -1,0 +1,116 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+/**
+ The possible kinds of motion curves that can be used to describe an animation.
+ */
+typedef NS_ENUM(NSUInteger, MDMMotionCurveType) {
+  /**
+   The value will be instantly set with no animation.
+   */
+  MDMMotionCurveTypeInstant,
+
+  /**
+   The value will be animated using a cubic bezier curve to model its velocity.
+   */
+  MDMMotionCurveTypeBezier,
+
+  /**
+   The value will be animated using a spring simulation.
+
+   A spring will treat the duration property of the motion timing as a suggestion and may choose to
+   ignore it altogether.
+   */
+  MDMMotionCurveTypeSpring,
+
+  /**
+   The default curve will be used.
+   */
+  MDMMotionCurveTypeDefault,
+
+} NS_SWIFT_NAME(MotionCurveType);
+
+/**
+ A generalized representation of a motion curve.
+ */
+struct MDMMotionCurve {
+  /**
+   The type defines how to interpret the data values.
+   */
+  MDMMotionCurveType type;
+
+  /**
+   The data values corresponding with this curve.
+   */
+  CGFloat data[4];
+} NS_SWIFT_NAME(MotionCurve);
+typedef struct MDMMotionCurve MDMMotionCurve;
+
+/**
+ Creates a bezier motion curve with the provided control points.
+
+ A cubic bezier has four control points in total. We assume that the first control point is 0, 0 and
+ the last control point is 1, 1. This method requires that you provide the second and third control
+ points.
+
+ See the documentation for CAMediaTimingFunction for more information.
+ */
+FOUNDATION_EXTERN MDMMotionCurve MDMMotionCurveMakeBezier(float p1x, float p1y, float p2x, float p2y)
+NS_SWIFT_NAME(MotionCurveMakeBezier(p1x:p1y:p2x:p2y:));
+
+/**
+ Creates a spring curve with the provided configuration.
+
+ Tension and friction map to Core Animation's stiffness and damping, respectively.
+
+ See the documentation for CASpringAnimation for more information.
+ */
+FOUNDATION_EXTERN MDMMotionCurve MDMMotionCurveMakeSpring(float mass, float tension, float friction)
+NS_SWIFT_NAME(MotionCurveMakeSpring(mass:tension:friction:));
+
+/**
+ Named indices for the bezier motion curve's data array.
+ */
+typedef NS_ENUM(NSUInteger, MDMBezierMotionCurveDataIndex) {
+  MDMBezierMotionCurveDataIndexP1X,
+  MDMBezierMotionCurveDataIndexP1Y,
+  MDMBezierMotionCurveDataIndexP2X,
+  MDMBezierMotionCurveDataIndexP2Y
+} NS_SWIFT_NAME(BezierMotionCurveDataIndex);
+
+/**
+ Named indices for the spring motion curve's data array.
+ */
+typedef NS_ENUM(NSUInteger, MDMSpringMotionCurveDataIndex) {
+  MDMSpringMotionCurveDataIndexMass,
+  MDMSpringMotionCurveDataIndexTension,
+  MDMSpringMotionCurveDataIndexFriction
+} NS_SWIFT_NAME(SpringMotionCurveDataIndex);
+
+// Objective-C-specific macros
+
+#define _MDMBezier(p1x, p1y, p2x, p2y) (MDMMotionCurve){ \
+  .type = MDMMotionCurveTypeBezier, \
+  .data = {p1x, p1y, p2x, p2y} \
+}
+
+#define _MDMSpring(mass, tension, friction) (MDMMotionCurve){ \
+  .type = MDMMotionCurveTypeSpring, \
+  .data = {mass, tension, friction} \
+}

--- a/src/MDMMotionCurve.m
+++ b/src/MDMMotionCurve.m
@@ -1,0 +1,25 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDMMotionCurve.h"
+
+MDMMotionCurve MDMMotionCurveMakeBezier(float p1x, float p1y, float p2x, float p2y) {
+  return _MDMBezier(p1x, p1y, p2x, p2y);
+}
+
+MDMMotionCurve MDMMotionCurveMakeSpring(float mass, float tension, float friction) {
+  return _MDMSpring(mass, tension, friction);
+}

--- a/src/MDMMotionRepetition.h
+++ b/src/MDMMotionRepetition.h
@@ -1,0 +1,70 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+/**
+ The possible kinds of repetition that can be used to describe an animation.
+ */
+typedef NS_ENUM(NSUInteger, MDMMotionRepetitionType) {
+  /**
+   The animation will be not be repeated.
+   */
+  MDMMotionRepetitionTypeNone,
+
+  /**
+   The animation will be repeated a given number of times.
+   */
+  MDMMotionRepetitionTypeCount,
+
+  /**
+   The animation will be repeated for a given number of seconds.
+   */
+  MDMMotionRepetitionTypeDuration,
+
+} NS_SWIFT_NAME(MotionReptitionType);
+
+/**
+ A generalized representation of a motion curve.
+ */
+struct MDMMotionRepetition {
+
+  /**
+   The type defines how to interpret the amount.
+   */
+  MDMMotionRepetitionType type;
+
+  /**
+   The amount of repetition.
+   */
+  double amount;
+
+  /**
+   Whether the animation should animate backwards after animating forwards.
+   */
+  BOOL autoreverses;
+
+} NS_SWIFT_NAME(MotionRepetition);
+typedef struct MDMMotionRepetition MDMMotionRepetition;
+
+// Objective-C-specific macros
+
+#define _MDMNoRepetition (MDMMotionRepetition){ \
+  .type = MDMMotionRepetitionTypeNone, \
+  .amount = 0, \
+  .autoreverses = false \
+}

--- a/src/MDMMotionTiming.h
+++ b/src/MDMMotionTiming.h
@@ -1,0 +1,49 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
+#import "MDMMotionCurve.h"
+#import "MDMMotionRepetition.h"
+
+/**
+ A representation of timing for an animation.
+ */
+struct MDMMotionTiming {
+
+  /**
+   The amount of time, in seconds, before this animation's value interpolation should begin.
+   */
+  CFTimeInterval delay;
+
+  /**
+   The amount of time, in seconds, over which this animation should interpolate between its values.
+   */
+  CFTimeInterval duration;
+
+  /**
+   The velocity and acceleration of the animation over time.
+   */
+  MDMMotionCurve curve;
+
+  /**
+   The repetition characteristics of the animation.
+   */
+  MDMMotionRepetition repetition;
+
+} NS_SWIFT_NAME(MotionTiming);
+typedef struct MDMMotionTiming MDMMotionTiming;

--- a/tests/unit/MDMMotionCurveTests.m
+++ b/tests/unit/MDMMotionCurveTests.m
@@ -1,0 +1,56 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <XCTest/XCTest.h>
+
+@import MotionInterchange;
+
+@interface MDMMotionCurveTests : XCTestCase
+@end
+
+@implementation MDMMotionCurveTests
+
+- (void)testBezierCurveData {
+  MDMMotionCurve curve = MDMMotionCurveMakeBezier(0.1, 0.2, 0.3, 0.4);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP1X], 0.1, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP1Y], 0.2, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP2X], 0.3, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP2Y], 0.4, 0.001);
+}
+
+- (void)testSpringCurveData {
+  MDMMotionCurve curve = MDMMotionCurveMakeSpring(0.1, 0.2, 0.3);
+  XCTAssertEqualWithAccuracy(curve.data[MDMSpringMotionCurveDataIndexMass], 0.1, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMSpringMotionCurveDataIndexTension], 0.2, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMSpringMotionCurveDataIndexFriction], 0.3, 0.001);
+}
+
+- (void)testBezierCurveDataWithMacro {
+  MDMMotionCurve curve = _MDMBezier(0.1, 0.2, 0.3, 0.4);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP1X], 0.1, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP1Y], 0.2, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP2X], 0.3, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMBezierMotionCurveDataIndexP2Y], 0.4, 0.001);
+}
+
+- (void)testSpringCurveDataWithMacro {
+  MDMMotionCurve curve = _MDMSpring(0.1, 0.2, 0.3);
+  XCTAssertEqualWithAccuracy(curve.data[MDMSpringMotionCurveDataIndexMass], 0.1, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMSpringMotionCurveDataIndexTension], 0.2, 0.001);
+  XCTAssertEqualWithAccuracy(curve.data[MDMSpringMotionCurveDataIndexFriction], 0.3, 0.001);
+}
+
+@end

--- a/tests/unit/MDMMotionCurveTests.swift
+++ b/tests/unit/MDMMotionCurveTests.swift
@@ -1,0 +1,37 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import XCTest
+import MotionInterchange
+
+class MDMMotionCurveTests: XCTestCase {
+
+  func testBezierCurveData() {
+    let curve = MotionCurveMakeBezier(p1x: 0.1, p1y: 0.2, p2x: 0.3, p2y: 0.4)
+    XCTAssertEqualWithAccuracy(curve.data.0, 0.1, accuracy: 0.001)
+    XCTAssertEqualWithAccuracy(curve.data.1, 0.2, accuracy: 0.001)
+    XCTAssertEqualWithAccuracy(curve.data.2, 0.3, accuracy: 0.001)
+    XCTAssertEqualWithAccuracy(curve.data.3, 0.4, accuracy: 0.001)
+  }
+
+  func testSpringCurveData() {
+    let curve = MotionCurveMakeSpring(mass: 0.1, tension: 0.2, friction: 0.3)
+    XCTAssertEqualWithAccuracy(curve.data.0, 0.1, accuracy: 0.001) // mass
+    XCTAssertEqualWithAccuracy(curve.data.1, 0.2, accuracy: 0.001) // tension
+    XCTAssertEqualWithAccuracy(curve.data.2, 0.3, accuracy: 0.001) // friction
+    XCTAssertEqualWithAccuracy(curve.data.3, 0.0, accuracy: 0.001)
+  }
+}


### PR DESCRIPTION
The motion interchange is a structured format for representing motion timing information in an application.

Includes support for the following types of curves: instant, bezier, and spring.

Also includes support for repetition behavior.

An example of how this will be used to build the Material FAB transition component:

```swift
struct MDCMaskedTransitionMotionTiming {
  MDMMotionTiming contentFade;
  MDMMotionTiming floodBackgroundColor;
  MDMMotionTiming maskTransformation;
  MDMMotionTiming horizontalMovement;
  MDMMotionTiming verticalMovement;
  MDMMotionTiming scrimFade;
};
typedef struct MDCMaskedTransitionMotionTiming MDCMaskedTransitionMotionTiming;

struct MDCMaskedTransitionMotion {
  MDCMaskedTransitionMotionSpec expansion;
  MDCMaskedTransitionMotionSpec collapse;
  BOOL shouldSlideWhenCollapsed;
  BOOL isCentered;
};
typedef struct MDCMaskedTransitionMotion MDCMaskedTransitionMotion;

#define MDMEightyForty _MDMBezier(0.4f, 0.0f, 0.2f, 1.0f)
#define MDMFortyOut _MDMBezier(0.4f, 0.0f, 1.0f, 1.0f)
#define MDMEightyIn _MDMBezier(0.0f, 0.0f, 0.2f, 1.0f)

struct MDCMaskedTransitionMotion fullscreen = {
  .expansion = {
    .contentFade = {
      .delay = 0.150, .duration = 0.225, .curve = MDMEightyForty,
    },
    .floodBackgroundColor = {
      .delay = 0.000, .duration = 0.075, .curve = MDMEightyForty,
    },
    .maskTransformation = {
      .delay = 0.000, .duration = 0.105, .curve = MDMFortyOut,
    },
    .horizontalMovement = {.curve = { .type = MDMMotionCurveTypeInstant }},
    .verticalMovement = {
      .delay = 0.045, .duration = 0.330, .curve = MDMEightyForty,
    },
    .scrimFade = {
      .delay = 0.000, .duration = 0.150, .curve = MDMEightyForty,
    }
  },
  .shouldSlideWhenCollapsed = true,
  .isCentered = false
};
```