### PR TITLE
Deprecate MDMMotionCurveTypeDefault in favor of MDMMotionCurveTypeBezier

### DIFF
--- a/src/MDMMotionCurve.h
+++ b/src/MDMMotionCurve.h
@@ -43,7 +43,7 @@ typedef NS_ENUM(NSUInteger, MDMMotionCurveType) {
   /**
    The default curve will be used.
    */
-  MDMMotionCurveTypeDefault,
+  MDMMotionCurveTypeDefault __deprecated_enum_msg("Use MDMMotionCurveTypeBezier instead."),
 
 } NS_SWIFT_NAME(MotionCurveType);
 


### PR DESCRIPTION
The default curve type is prone to confusion and unclear behavior and will be removed in a subsequent release.