### PR TITLE
Add support for damping ratio initializers on the spring timing curve.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,6 +37,7 @@ strict_warnings_objc_library(
         "CoreGraphics",
         "Foundation",
         "QuartzCore",
+        "UIKit",
     ],
     enable_modules = 1,
     includes = ["src"],

--- a/README.md
+++ b/README.md
@@ -172,6 +172,22 @@ let timingCurve = MDMSpringTimingCurve(mass: 1, tension: 100, friction: 10)
 let traits = MDMAnimationTraits(delay: 0, duration: 0.5, timingCurve: timingCurve)
 ```
 
+Springs can also be initialized using UIKit's [damping ratio concept](https://developer.apple.com/documentation/uikit/uiview/1622594-animatewithduration):
+
+```objc
+MDMSpringTimingCurve *timingCurve =
+    [[MDMSpringTimingCurve alloc] initWithDuration:0.5 dampingRatio:0.5];
+MDMAnimationTraits *traits =
+    [[MDMAnimationTraits alloc] initWithDelay:0 duration:0.5 timingCurve:timingCurve];
+```
+
+And in Swift:
+
+```swift
+let timingCurve = MDMSpringTimingCurve(duration: 0.5, dampingRatio: 0.5)
+let traits = MDMAnimationTraits(delay: 0, duration: 0.5, timingCurve: timingCurve)
+```
+
 ## Contributing
 
 We welcome contributions!

--- a/src/MDMAnimationTraits.h
+++ b/src/MDMAnimationTraits.h
@@ -136,3 +136,4 @@
 @property(nonatomic, class, strong, nonnull, readonly) MDMAnimationTraits *systemModalMovement;
 
 @end
+

--- a/src/MDMAnimationTraits.h
+++ b/src/MDMAnimationTraits.h
@@ -136,4 +136,3 @@
 @property(nonatomic, class, strong, nonnull, readonly) MDMAnimationTraits *systemModalMovement;
 
 @end
-

--- a/src/MDMSpringTimingCurve.h
+++ b/src/MDMSpringTimingCurve.h
@@ -55,6 +55,35 @@
                      initialVelocity:(CGFloat)initialVelocity
     NS_DESIGNATED_INITIALIZER;
 
+/**
+ Initializes the timing curve with the given UIKit spring damping ratio.
+
+ @param duration The desired duration of the spring animation.
+ @param dampingRatio From the UIKit documentation: "When `dampingRatio` is 1, the animation will
+ smoothly decelerate to its final model values without oscillating. Damping ratios less than 1 will
+ oscillate more and more before coming to a complete stop."
+ */
+- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
+                            dampingRatio:(CGFloat)dampingRatio;
+
+/**
+ Initializes the timing curve with the given UIKit spring damping ratio and initial velocity.
+
+ @param duration The desired duration of the spring animation.
+ @param dampingRatio From the UIKit documentation: "When `dampingRatio` is 1, the animation will
+ smoothly decelerate to its final model values without oscillating. Damping ratios less than 1 will
+ oscillate more and more before coming to a complete stop."
+ @param initialVelocity From the UIKit documentation: "You can use the initial spring velocity to
+ specify how fast the object at the end of the simulated spring was moving before it was attached.
+ It's a unit coordinate system, where 1 is defined as travelling the total animation distance in a
+ second. So if you're changing an object's position by 200pt in this animation, and you want the
+ animation to behave as if the object was moving at 100pt/s before the animation started, you'd
+ pass 0.5. You'll typically want to pass 0 for the velocity."
+ */
+- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
+                            dampingRatio:(CGFloat)dampingRatio
+                         initialVelocity:(CGFloat)initialVelocity;
+
 #pragma mark - Traits
 
 /**
@@ -91,5 +120,3 @@
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
 @end
-
-

--- a/src/MDMSpringTimingCurve.m
+++ b/src/MDMSpringTimingCurve.m
@@ -109,7 +109,7 @@
   // linking against the public API on iOS 9+.
 #pragma clang diagnostic ignored "-Wpartial-availability"
   CASpringAnimation *springAnimation =
-  (CASpringAnimation *)[view.layer animationForKey:animationKey];
+      (CASpringAnimation *)[view.layer animationForKey:animationKey];
   NSAssert([springAnimation isKindOfClass:[CASpringAnimation class]],
            @"Unable to extract animation timing curve: unexpected animation type.");
 #pragma clang diagnostic pop

--- a/src/MDMSpringTimingCurve.m
+++ b/src/MDMSpringTimingCurve.m
@@ -16,7 +16,16 @@
 
 #import "MDMSpringTimingCurve.h"
 
-@implementation MDMSpringTimingCurve
+@implementation MDMSpringTimingCurve {
+  CGFloat _duration;
+  CGFloat _dampingRatio;
+
+  BOOL _coefficientsAreInvalid;
+}
+
+@synthesize mass = _mass;
+@synthesize friction = _friction;
+@synthesize tension = _tension;
 
 - (instancetype)init {
   [self doesNotRecognizeSelector:_cmd];
@@ -30,31 +39,13 @@
 - (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
                             dampingRatio:(CGFloat)dampingRatio
                          initialVelocity:(CGFloat)initialVelocity {
-  UIView *view = [[UIView alloc] init];
-  [UIView animateWithDuration:duration
-                        delay:0
-       usingSpringWithDamping:dampingRatio
-        initialSpringVelocity:initialVelocity
-                      options:0
-                   animations:^{
-    view.center = CGPointMake(100, 100);
-  } completion:nil];
-
-  NSString *animationKey = [view.layer.animationKeys firstObject];
-  NSAssert(animationKey != nil, @"Unable to extract animation timing curve: no animation found.");
-#pragma clang diagnostic push
-  // CASpringAnimation is a private API on iOS 8 - we're able to make use of it because we're
-  // linking against the public API on iOS 9+.
-#pragma clang diagnostic ignored "-Wpartial-availability"
-  CASpringAnimation *springAnimation =
-      (CASpringAnimation *)[view.layer animationForKey:animationKey];
-  NSAssert([springAnimation isKindOfClass:[CASpringAnimation class]],
-           @"Unable to extract animation timing curve: unexpected animation type.");
-#pragma clang diagnostic pop
-  return [self initWithMass:springAnimation.mass
-                    tension:springAnimation.stiffness
-                   friction:springAnimation.damping
-            initialVelocity:springAnimation.initialVelocity];
+  self = [self initWithMass:0 tension:0 friction:0 initialVelocity:initialVelocity];
+  if (self) {
+    _duration = duration;
+    _dampingRatio = dampingRatio;
+    _coefficientsAreInvalid = YES;
+  }
+  return self;
 }
 
 - (instancetype)initWithMass:(CGFloat)mass tension:(CGFloat)tension friction:(CGFloat)friction {
@@ -73,6 +64,59 @@
     _initialVelocity = initialVelocity;
   }
   return self;
+}
+
+- (CGFloat)mass {
+  [self recalculateCoefficientsIfNeeded];
+  return _mass;
+}
+
+- (CGFloat)tension {
+  [self recalculateCoefficientsIfNeeded];
+  return _tension;
+}
+
+- (CGFloat)friction {
+  [self recalculateCoefficientsIfNeeded];
+  return _friction;
+}
+
+#pragma mark - Private
+
+- (void)recalculateCoefficientsIfNeeded {
+  if (_coefficientsAreInvalid) {
+    [self recalculateCoefficients];
+  }
+}
+
+- (void)recalculateCoefficients {
+  UIView *view = [[UIView alloc] init];
+  [UIView animateWithDuration:_duration
+                        delay:0
+       usingSpringWithDamping:_dampingRatio
+        initialSpringVelocity:self.initialVelocity
+                      options:0
+                   animations:^{
+                     view.center = CGPointMake(100, 100);
+                   } completion:nil];
+
+  NSString *animationKey = [view.layer.animationKeys firstObject];
+  NSAssert(animationKey != nil, @"Unable to extract animation timing curve: no animation found.");
+#pragma clang diagnostic push
+  // CASpringAnimation is a private API on iOS 8 - we're able to make use of it because we're
+  // linking against the public API on iOS 9+.
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  CASpringAnimation *springAnimation =
+  (CASpringAnimation *)[view.layer animationForKey:animationKey];
+  NSAssert([springAnimation isKindOfClass:[CASpringAnimation class]],
+           @"Unable to extract animation timing curve: unexpected animation type.");
+#pragma clang diagnostic pop
+
+  _mass = springAnimation.mass;
+  _tension = springAnimation.stiffness;
+  _friction = springAnimation.damping;
+
+  _coefficientsAreInvalid = NO;
 }
 
 @end

--- a/src/MDMSpringTimingCurve.m
+++ b/src/MDMSpringTimingCurve.m
@@ -16,6 +16,8 @@
 
 #import "MDMSpringTimingCurve.h"
 
+#import <UIKit/UIKit.h>
+
 @implementation MDMSpringTimingCurve {
   CGFloat _duration;
   CGFloat _dampingRatio;

--- a/src/MDMSpringTimingCurve.m
+++ b/src/MDMSpringTimingCurve.m
@@ -23,6 +23,40 @@
   return nil;
 }
 
+- (instancetype)initWithDuration:(NSTimeInterval)duration dampingRatio:(CGFloat)dampingRatio {
+  return [self initWithDuration:duration dampingRatio:dampingRatio initialVelocity:0];
+}
+
+- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
+                            dampingRatio:(CGFloat)dampingRatio
+                         initialVelocity:(CGFloat)initialVelocity {
+  UIView *view = [[UIView alloc] init];
+  [UIView animateWithDuration:duration
+                        delay:0
+       usingSpringWithDamping:dampingRatio
+        initialSpringVelocity:initialVelocity
+                      options:0
+                   animations:^{
+    view.center = CGPointMake(100, 100);
+  } completion:nil];
+
+  NSString *animationKey = [view.layer.animationKeys firstObject];
+  NSAssert(animationKey != nil, @"Unable to extract animation timing curve: no animation found.");
+#pragma clang diagnostic push
+  // CASpringAnimation is a private API on iOS 8 - we're able to make use of it because we're
+  // linking against the public API on iOS 9+.
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  CASpringAnimation *springAnimation =
+      (CASpringAnimation *)[view.layer animationForKey:animationKey];
+  NSAssert([springAnimation isKindOfClass:[CASpringAnimation class]],
+           @"Unable to extract animation timing curve: unexpected animation type.");
+#pragma clang diagnostic pop
+  return [self initWithMass:springAnimation.mass
+                    tension:springAnimation.stiffness
+                   friction:springAnimation.damping
+            initialVelocity:springAnimation.initialVelocity];
+}
+
 - (instancetype)initWithMass:(CGFloat)mass tension:(CGFloat)tension friction:(CGFloat)friction {
   return [self initWithMass:mass tension:tension friction:friction initialVelocity:0];
 }

--- a/tests/unit/MDMSpringTimingCurve.swift
+++ b/tests/unit/MDMSpringTimingCurve.swift
@@ -34,4 +34,36 @@ class MDMTimingCurveTests: XCTestCase {
     XCTAssertEqualWithAccuracy(curve.friction, 0.3, accuracy: 0.001)
     XCTAssertEqualWithAccuracy(curve.initialVelocity, 0.4, accuracy: 0.001)
   }
+
+  @available(iOS 9.0, *)
+  func testInitializerValuesWithDampingCoefficient() {
+    for duration in stride(from: TimeInterval(0.1), to: TimeInterval(3), by: TimeInterval(0.5)) {
+      for dampingRatio in stride(from: CGFloat(0.1), to: CGFloat(2), by: CGFloat(0.4)) {
+        for initialVelocity in stride(from: CGFloat(-2), to: CGFloat(2), by: CGFloat(0.8)) {
+          let curve = MDMSpringTimingCurve(duration: duration,
+                                           dampingRatio: dampingRatio,
+                                           initialVelocity: initialVelocity)
+          let view = UIView()
+
+          UIView.animate(withDuration: duration,
+                         delay: 0,
+                         usingSpringWithDamping: dampingRatio,
+                         initialSpringVelocity: initialVelocity,
+                         options: [],
+                         animations: {
+                          view.center = CGPoint(x: initialVelocity * 5, y: dampingRatio * 10)
+          }, completion: nil)
+
+          if let animationKey = view.layer.animationKeys()?.first,
+            let animation = view.layer.animation(forKey: animationKey) as? CASpringAnimation {
+
+            XCTAssertEqualWithAccuracy(curve.mass, animation.mass, accuracy: 0.001)
+            XCTAssertEqualWithAccuracy(curve.tension, animation.stiffness, accuracy: 0.001)
+            XCTAssertEqualWithAccuracy(curve.friction, animation.damping, accuracy: 0.001)
+            XCTAssertEqualWithAccuracy(curve.initialVelocity, animation.initialVelocity, accuracy: 0.001)
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
These initializers match the UIKit equivalent APIs.