### PR TITLE
Use UIViewAnimationCurve instead of NSString as the easing curve type.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -37,6 +37,7 @@ strict_warnings_objc_library(
         "CoreGraphics",
         "Foundation",
         "QuartzCore",
+        "UIKit",
     ],
     enable_modules = 1,
     includes = ["src"],

--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ let timingCurve = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOu
 let traits = MDMAnimationTraits(delay: 0, duration: 0.5, timingCurve: timingCurve)
 ```
 
+You can also use the UIViewAnimationCurve type to initialize a timing curve in Objective-C:
+
+```objc
+MDMAnimationTraits *traits =
+    [[MDMAnimationTraits alloc] initWithDuration:0.5 animationCurve:UIViewAnimationCurveEaseIn];
+```
+
+And in Swift:
+
+```swift
+let traits = MDMAnimationTraits(duration: 0.5, animationCurve: .easeIn)
+```
+
 **Springs** are represented with the custom `MDMSpringTimingCurve` type. To define an
 animation trait with a spring curve in Objective-C:
 

--- a/src/MDMAnimationTraits.h
+++ b/src/MDMAnimationTraits.h
@@ -16,6 +16,7 @@
 
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #import "MDMRepetitionTraits.h"
 #import "MDMTimingCurve.h"

--- a/src/MDMAnimationTraits.h
+++ b/src/MDMAnimationTraits.h
@@ -37,10 +37,10 @@
  Initializes the instance with the provided duration and named bezier timing curve.
 
  @param duration The animation will occur over this length of time, in seconds.
- @param timingFunctionName A kCAMediaTimingFunction name representing a cubic bezier timing curve.
+ @param animationCurve A UIKit bezier animation curve type.
  */
 - (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
-                      timingFunctionName:(nonnull NSString *)timingFunctionName;
+                          animationCurve:(UIViewAnimationCurve)animationCurve;
 
 /**
  Initializes the instance with the provided duration, delay, and
@@ -61,11 +61,11 @@
  @param delay The amount of time, in seconds, to wait before starting the animation.
  @param duration The animation will occur over this length of time, in seconds, after the delay time
  has passed.
- @param timingFunctionName A kCAMediaTimingFunction name representing a cubic bezier timing curve.
+ @param animationCurve A UIKit bezier animation curve type.
  */
 - (nonnull instancetype)initWithDelay:(NSTimeInterval)delay
                              duration:(NSTimeInterval)duration
-                   timingFunctionName:(nonnull NSString *)timingFunctionName;
+                       animationCurve:(UIViewAnimationCurve)animationCurve;
 
 /**
  Initializes the instance with the provided duration, delay, and timing curve.

--- a/src/MDMAnimationTraits.m
+++ b/src/MDMAnimationTraits.m
@@ -31,20 +31,32 @@
 }
 
 - (instancetype)initWithDuration:(NSTimeInterval)duration
-              timingFunctionName:(NSString *)timingFunctionName {
-  return [self initWithDelay:0 duration:duration timingFunctionName:timingFunctionName];
+                  animationCurve:(UIViewAnimationCurve)animationCurve {
+  return [self initWithDelay:0 duration:duration animationCurve:animationCurve];
 }
 
 - (instancetype)initWithDelay:(NSTimeInterval)delay duration:(NSTimeInterval)duration {
-  return [self initWithDelay:delay
-                    duration:duration
-          timingFunctionName:kCAMediaTimingFunctionEaseInEaseOut];
+  return [self initWithDelay:delay duration:duration animationCurve:UIViewAnimationCurveEaseInOut];
 }
 
 - (instancetype)initWithDelay:(NSTimeInterval)delay
                      duration:(NSTimeInterval)duration
-           timingFunctionName:(NSString *)timingFunctionName {
-  CAMediaTimingFunction *timingCurve = [CAMediaTimingFunction functionWithName:timingFunctionName];
+               animationCurve:(UIViewAnimationCurve)animationCurve {
+  CAMediaTimingFunction *timingCurve;
+  switch (animationCurve) {
+    case UIViewAnimationCurveEaseInOut:
+      timingCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut];
+      break;
+    case UIViewAnimationCurveEaseIn:
+      timingCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseIn];
+      break;
+    case UIViewAnimationCurveEaseOut:
+      timingCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseOut];
+      break;
+    case UIViewAnimationCurveLinear:
+      timingCurve = [CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionLinear];
+      break;
+  }
   return [self initWithDelay:delay duration:duration timingCurve:timingCurve];
 }
 

--- a/tests/unit/MDMAnimationTraitsTests.swift
+++ b/tests/unit/MDMAnimationTraitsTests.swift
@@ -35,6 +35,22 @@ class MDMAnimationTraitsTests: XCTestCase {
     XCTAssertNil(traits.repetition)
   }
 
+  func testInitializerValuesWithDurationAndEaseInCurve() {
+    let traits = MDMAnimationTraits(duration: 0.5, animationCurve: .easeIn)
+
+    XCTAssertEqualWithAccuracy(traits.duration, 0.5, accuracy: 0.001)
+    XCTAssertEqualWithAccuracy(traits.delay, 0, accuracy: 0.001)
+    XCTAssertTrue(traits.timingCurve is CAMediaTimingFunction)
+    if let timingCurve = traits.timingCurve as? CAMediaTimingFunction {
+      let easeInOut = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseIn)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.x, easeInOut.mdm_point1.x, accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point1.y, easeInOut.mdm_point1.y, accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.x, easeInOut.mdm_point2.x, accuracy: 0.001)
+      XCTAssertEqualWithAccuracy(timingCurve.mdm_point2.y, easeInOut.mdm_point2.y, accuracy: 0.001)
+    }
+    XCTAssertNil(traits.repetition)
+  }
+
   func testInitializerValuesWithDurationDelay() {
     let traits = MDMAnimationTraits(delay: 0.2, duration: 0.5)
 


### PR DESCRIPTION
This gives better compile-time enforcement and auto-completion than the Core Animation strings.