### PR TITLE
Extract the UIKit damping ratio APIs to their own class.

### DIFF
--- a/src/MDMSpringTimingCurve.h
+++ b/src/MDMSpringTimingCurve.h
@@ -55,35 +55,6 @@
                      initialVelocity:(CGFloat)initialVelocity
     NS_DESIGNATED_INITIALIZER;
 
-/**
- Initializes the timing curve with the given UIKit spring damping ratio.
-
- @param duration The desired duration of the spring animation.
- @param dampingRatio From the UIKit documentation: "When `dampingRatio` is 1, the animation will
- smoothly decelerate to its final model values without oscillating. Damping ratios less than 1 will
- oscillate more and more before coming to a complete stop."
- */
-- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
-                            dampingRatio:(CGFloat)dampingRatio;
-
-/**
- Initializes the timing curve with the given UIKit spring damping ratio and initial velocity.
-
- @param duration The desired duration of the spring animation.
- @param dampingRatio From the UIKit documentation: "When `dampingRatio` is 1, the animation will
- smoothly decelerate to its final model values without oscillating. Damping ratios less than 1 will
- oscillate more and more before coming to a complete stop."
- @param initialVelocity From the UIKit documentation: "You can use the initial spring velocity to
- specify how fast the object at the end of the simulated spring was moving before it was attached.
- It's a unit coordinate system, where 1 is defined as travelling the total animation distance in a
- second. So if you're changing an object's position by 200pt in this animation, and you want the
- animation to behave as if the object was moving at 100pt/s before the animation started, you'd
- pass 0.5. You'll typically want to pass 0 for the velocity."
- */
-- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
-                            dampingRatio:(CGFloat)dampingRatio
-                         initialVelocity:(CGFloat)initialVelocity;
-
 #pragma mark - Traits
 
 /**

--- a/src/MDMSpringTimingCurve.m
+++ b/src/MDMSpringTimingCurve.m
@@ -16,8 +16,6 @@
 
 #import "MDMSpringTimingCurve.h"
 
-#import <UIKit/UIKit.h>
-
 @implementation MDMSpringTimingCurve
 
 - (instancetype)init {

--- a/src/MDMSpringTimingCurve.m
+++ b/src/MDMSpringTimingCurve.m
@@ -18,36 +18,11 @@
 
 #import <UIKit/UIKit.h>
 
-@implementation MDMSpringTimingCurve {
-  CGFloat _duration;
-  CGFloat _dampingRatio;
-
-  BOOL _coefficientsAreInvalid;
-}
-
-@synthesize mass = _mass;
-@synthesize friction = _friction;
-@synthesize tension = _tension;
+@implementation MDMSpringTimingCurve
 
 - (instancetype)init {
   [self doesNotRecognizeSelector:_cmd];
   return nil;
-}
-
-- (instancetype)initWithDuration:(NSTimeInterval)duration dampingRatio:(CGFloat)dampingRatio {
-  return [self initWithDuration:duration dampingRatio:dampingRatio initialVelocity:0];
-}
-
-- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
-                            dampingRatio:(CGFloat)dampingRatio
-                         initialVelocity:(CGFloat)initialVelocity {
-  self = [self initWithMass:0 tension:0 friction:0 initialVelocity:initialVelocity];
-  if (self) {
-    _duration = duration;
-    _dampingRatio = dampingRatio;
-    _coefficientsAreInvalid = YES;
-  }
-  return self;
 }
 
 - (instancetype)initWithMass:(CGFloat)mass tension:(CGFloat)tension friction:(CGFloat)friction {
@@ -68,78 +43,16 @@
   return self;
 }
 
-- (CGFloat)mass {
-  [self recalculateCoefficientsIfNeeded];
-  return _mass;
-}
-
-- (CGFloat)tension {
-  [self recalculateCoefficientsIfNeeded];
-  return _tension;
-}
-
-- (CGFloat)friction {
-  [self recalculateCoefficientsIfNeeded];
-  return _friction;
-}
-
-- (void)setInitialVelocity:(CGFloat)initialVelocity {
-  _initialVelocity = initialVelocity;
-
-  _coefficientsAreInvalid = YES;
-}
-
 #pragma mark - NSCopying
 
 - (id)copyWithZone:(NSZone *)zone {
-  MDMSpringTimingCurve *copy =
-      [[[self class] allocWithZone:zone] initWithMass:self.mass
-                                              tension:self.tension
-                                             friction:self.friction
-                                      initialVelocity:self.initialVelocity];
-  copy->_coefficientsAreInvalid = _coefficientsAreInvalid;
-  copy->_duration = _duration;
-  copy->_dampingRatio = _dampingRatio;
-  return copy;
+  return [[[self class] allocWithZone:zone] initWithMass:self.mass
+                                                 tension:self.tension
+                                                friction:self.friction
+                                         initialVelocity:self.initialVelocity];;
 }
 
 #pragma mark - Private
-
-- (void)recalculateCoefficientsIfNeeded {
-  if (_coefficientsAreInvalid) {
-    [self recalculateCoefficients];
-  }
-}
-
-- (void)recalculateCoefficients {
-  UIView *view = [[UIView alloc] init];
-  [UIView animateWithDuration:_duration
-                        delay:0
-       usingSpringWithDamping:_dampingRatio
-        initialSpringVelocity:self.initialVelocity
-                      options:0
-                   animations:^{
-                     view.center = CGPointMake(100, 100);
-                   } completion:nil];
-
-  NSString *animationKey = [view.layer.animationKeys firstObject];
-  NSAssert(animationKey != nil, @"Unable to extract animation timing curve: no animation found.");
-#pragma clang diagnostic push
-  // CASpringAnimation is a private API on iOS 8 - we're able to make use of it because we're
-  // linking against the public API on iOS 9+.
-#pragma clang diagnostic ignored "-Wpartial-availability"
-  CASpringAnimation *springAnimation =
-      (CASpringAnimation *)[view.layer animationForKey:animationKey];
-  NSAssert([springAnimation isKindOfClass:[CASpringAnimation class]],
-           @"Unable to extract animation timing curve: unexpected animation type.");
-#pragma clang diagnostic pop
-
-  _mass = springAnimation.mass;
-  _tension = springAnimation.stiffness;
-  _friction = springAnimation.damping;
-
-  _coefficientsAreInvalid = NO;
-}
 
 @end
 

--- a/src/MDMSpringTimingCurveGenerator.h
+++ b/src/MDMSpringTimingCurveGenerator.h
@@ -1,0 +1,88 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+#import "MDMTimingCurve.h"
+
+@class MDMSpringTimingCurve;
+
+@interface MDMSpringTimingCurveGenerator : NSObject <NSCopying, MDMTimingCurve>
+
+/**
+ Initializes the timing curve with the given UIKit spring damping ratio.
+
+ @param duration The desired duration of the spring animation.
+ @param dampingRatio From the UIKit documentation: "When `dampingRatio` is 1, the animation will
+ smoothly decelerate to its final model values without oscillating. Damping ratios less than 1 will
+ oscillate more and more before coming to a complete stop."
+ */
+- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
+                            dampingRatio:(CGFloat)dampingRatio;
+
+/**
+ Initializes the timing curve with the given UIKit spring damping ratio and initial velocity.
+
+ @param duration The desired duration of the spring animation.
+ @param dampingRatio From the UIKit documentation: "When `dampingRatio` is 1, the animation will
+ smoothly decelerate to its final model values without oscillating. Damping ratios less than 1 will
+ oscillate more and more before coming to a complete stop."
+ @param initialVelocity From the UIKit documentation: "You can use the initial spring velocity to
+ specify how fast the object at the end of the simulated spring was moving before it was attached.
+ It's a unit coordinate system, where 1 is defined as travelling the total animation distance in a
+ second. So if you're changing an object's position by 200pt in this animation, and you want the
+ animation to behave as if the object was moving at 100pt/s before the animation started, you'd
+ pass 0.5. You'll typically want to pass 0 for the velocity."
+ */
+- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
+                            dampingRatio:(CGFloat)dampingRatio
+                         initialVelocity:(CGFloat)initialVelocity
+    NS_DESIGNATED_INITIALIZER;
+
+#pragma mark - Traits
+
+/**
+ The desired duration of the spring animation.
+ */
+@property(nonatomic, assign) NSTimeInterval duration;
+
+/**
+ From the UIKit documentation: "When `dampingRatio` is 1, the animation will
+ smoothly decelerate to its final model values without oscillating. Damping ratios less than 1 will
+ oscillate more and more before coming to a complete stop."
+ */
+@property(nonatomic, assign) CGFloat dampingRatio;
+
+/**
+ From the UIKit documentation: "You can use the initial spring velocity to
+ specify how fast the object at the end of the simulated spring was moving before it was attached.
+ It's a unit coordinate system, where 1 is defined as travelling the total animation distance in a
+ second. So if you're changing an object's position by 200pt in this animation, and you want the
+ animation to behave as if the object was moving at 100pt/s before the animation started, you'd
+ pass 0.5. You'll typically want to pass 0 for the velocity."
+ */
+@property(nonatomic, assign) CGFloat initialVelocity;
+
+/**
+ Creates and returns a new spring timing curve instance with the current configuration.
+ */
+- (nonnull MDMSpringTimingCurve *)springTimingCurve;
+
+/** Unavailable. */
+- (nonnull instancetype)init NS_UNAVAILABLE;
+
+@end

--- a/src/MDMSpringTimingCurveGenerator.h
+++ b/src/MDMSpringTimingCurveGenerator.h
@@ -21,6 +21,9 @@
 
 @class MDMSpringTimingCurve;
 
+/**
+ A spring timing curve generator based on UIKit duration/dampingRatio-based coefficients.
+ */
 @interface MDMSpringTimingCurveGenerator : NSObject <NSCopying, MDMTimingCurve>
 
 /**

--- a/src/MDMSpringTimingCurveGenerator.m
+++ b/src/MDMSpringTimingCurveGenerator.m
@@ -18,6 +18,8 @@
 
 #import "MDMSpringTimingCurve.h"
 
+#import <UIKit/UIKit.h>
+
 @implementation MDMSpringTimingCurveGenerator
 
 - (instancetype)initWithDuration:(NSTimeInterval)duration dampingRatio:(CGFloat)dampingRatio {

--- a/src/MDMSpringTimingCurveGenerator.m
+++ b/src/MDMSpringTimingCurveGenerator.m
@@ -1,0 +1,76 @@
+/*
+ Copyright 2017-present The Material Motion Authors. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "MDMSpringTimingCurveGenerator.h"
+
+#import "MDMSpringTimingCurve.h"
+
+@implementation MDMSpringTimingCurveGenerator
+
+- (instancetype)initWithDuration:(NSTimeInterval)duration dampingRatio:(CGFloat)dampingRatio {
+  return [self initWithDuration:duration dampingRatio:dampingRatio initialVelocity:0];
+}
+
+- (nonnull instancetype)initWithDuration:(NSTimeInterval)duration
+                            dampingRatio:(CGFloat)dampingRatio
+                         initialVelocity:(CGFloat)initialVelocity {
+  self = [super init];
+  if (self) {
+    _duration = duration;
+    _dampingRatio = dampingRatio;
+    _initialVelocity = initialVelocity;
+  }
+  return self;
+}
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+  return [[[self class] allocWithZone:zone] initWithDuration:self.duration
+                                                dampingRatio:self.dampingRatio
+                                             initialVelocity:self.initialVelocity];
+}
+
+- (MDMSpringTimingCurve *)springTimingCurve {
+  UIView *view = [[UIView alloc] init];
+  [UIView animateWithDuration:self.duration
+                        delay:0
+       usingSpringWithDamping:self.dampingRatio
+        initialSpringVelocity:self.initialVelocity
+                      options:0
+                   animations:^{
+                     view.center = CGPointMake(100, 100);
+                   } completion:nil];
+
+  NSString *animationKey = [view.layer.animationKeys firstObject];
+  NSAssert(animationKey != nil, @"Unable to extract animation timing curve: no animation found.");
+#pragma clang diagnostic push
+  // CASpringAnimation is a private API on iOS 8 - we're able to make use of it because we're
+  // linking against the public API on iOS 9+.
+#pragma clang diagnostic ignored "-Wpartial-availability"
+  CASpringAnimation *springAnimation =
+      (CASpringAnimation *)[view.layer animationForKey:animationKey];
+  NSAssert([springAnimation isKindOfClass:[CASpringAnimation class]],
+           @"Unable to extract animation timing curve: unexpected animation type.");
+#pragma clang diagnostic pop
+
+  return [[MDMSpringTimingCurve alloc] initWithMass:springAnimation.mass
+                                            tension:springAnimation.stiffness
+                                           friction:springAnimation.damping
+                                    initialVelocity:self.initialVelocity];
+}
+
+@end

--- a/src/MotionInterchange.h
+++ b/src/MotionInterchange.h
@@ -21,3 +21,4 @@
 #import "MDMRepetitionOverTime.h"
 #import "MDMTimingCurve.h"
 #import "MDMSpringTimingCurve.h"
+#import "MDMSpringTimingCurveGenerator.h"

--- a/tests/unit/MDMSpringTimingCurve.swift
+++ b/tests/unit/MDMSpringTimingCurve.swift
@@ -40,9 +40,9 @@ class MDMTimingCurveTests: XCTestCase {
     for duration in stride(from: TimeInterval(0.1), to: TimeInterval(3), by: TimeInterval(0.5)) {
       for dampingRatio in stride(from: CGFloat(0.1), to: CGFloat(2), by: CGFloat(0.4)) {
         for initialVelocity in stride(from: CGFloat(-2), to: CGFloat(2), by: CGFloat(0.8)) {
-          let curve = MDMSpringTimingCurve(duration: duration,
-                                           dampingRatio: dampingRatio,
-                                           initialVelocity: initialVelocity)
+          let generator = MDMSpringTimingCurveGenerator(duration: duration,
+                                                        dampingRatio: dampingRatio,
+                                                        initialVelocity: initialVelocity)
           let view = UIView()
 
           UIView.animate(withDuration: duration,
@@ -57,6 +57,7 @@ class MDMTimingCurveTests: XCTestCase {
           if let animationKey = view.layer.animationKeys()?.first,
             let animation = view.layer.animation(forKey: animationKey) as? CASpringAnimation {
 
+            let curve = generator.springTimingCurve()
             XCTAssertEqualWithAccuracy(curve.mass, animation.mass, accuracy: 0.001)
             XCTAssertEqualWithAccuracy(curve.tension, animation.stiffness, accuracy: 0.001)
             XCTAssertEqualWithAccuracy(curve.friction, animation.damping, accuracy: 0.001)
@@ -65,70 +66,5 @@ class MDMTimingCurveTests: XCTestCase {
         }
       }
     }
-  }
-
-  func testChangingInitialVelocityInvalidatesTheCoefficients() {
-    let curve = MDMSpringTimingCurve(duration: 0.5,
-                                     dampingRatio: 0.8,
-                                     initialVelocity: 0)
-
-    let originalMass = curve.mass
-    let originalTension = curve.tension
-    let originalFriction = curve.friction
-
-    curve.initialVelocity = 10
-
-    // UIKit never appears to change the mass.
-    XCTAssertEqualWithAccuracy(curve.mass, originalMass, accuracy: 0.001)
-    XCTAssertNotEqualWithAccuracy(curve.tension, originalTension, 0.001)
-    XCTAssertNotEqualWithAccuracy(curve.friction, originalFriction, 0.001)
-  }
-
-  func testWithDampingRatioSettingMassKeepsTheNewMass() {
-    let curve = MDMSpringTimingCurve(duration: 0.5,
-                                     dampingRatio: 0.8,
-                                     initialVelocity: 0)
-
-    let originalMass = curve.mass
-    let originalTension = curve.tension
-    let originalFriction = curve.friction
-
-    curve.mass = originalMass + 1
-
-    XCTAssertEqualWithAccuracy(curve.mass, originalMass + 1, accuracy: 0.001)
-    XCTAssertEqualWithAccuracy(curve.tension, originalTension, accuracy: 0.001)
-    XCTAssertEqualWithAccuracy(curve.friction, originalFriction, accuracy: 0.001)
-  }
-
-  func testWithDampingRatioSettingTensionKeepsTheNewTension() {
-    let curve = MDMSpringTimingCurve(duration: 0.5,
-                                     dampingRatio: 0.8,
-                                     initialVelocity: 0)
-
-    let originalMass = curve.mass
-    let originalTension = curve.tension
-    let originalFriction = curve.friction
-
-    curve.tension = originalTension + 1
-
-    XCTAssertEqualWithAccuracy(curve.mass, originalMass, accuracy: 0.001)
-    XCTAssertEqualWithAccuracy(curve.tension, originalTension + 1, accuracy: 0.001)
-    XCTAssertEqualWithAccuracy(curve.friction, originalFriction, accuracy: 0.001)
-  }
-
-  func testWithDampingRatioSettingFrictionKeepsTheNewFriction() {
-    let curve = MDMSpringTimingCurve(duration: 0.5,
-                                     dampingRatio: 0.8,
-                                     initialVelocity: 0)
-
-    let originalMass = curve.mass
-    let originalTension = curve.tension
-    let originalFriction = curve.friction
-
-    curve.friction = originalFriction + 1
-
-    XCTAssertEqualWithAccuracy(curve.mass, originalMass, accuracy: 0.001)
-    XCTAssertEqualWithAccuracy(curve.tension, originalTension, accuracy: 0.001)
-    XCTAssertEqualWithAccuracy(curve.friction, originalFriction + 1, accuracy: 0.001)
   }
 }


### PR DESCRIPTION
It was becoming difficult to document and test the behavior of the spring timing curve when it had both the explicit APIs and the UIKit dampingRatio variant in the same class. Making the UIKit API a generator simplifies the implementation.