### PR TITLE
Remove the xcode_select logic.

### DIFF
--- a/.kokoro
+++ b/.kokoro
@@ -64,7 +64,7 @@ run_bazel() {
     | cut -d'<' -f1)
 
   bazel clean
-  bazel test //... --xcode_version $xcode_version --ios_minimum_os=8.0 --ios_multi_cpus=i386,x86_64
+  bazel test //... --xcode_version $xcode_version --ios_minimum_os=8.0 --ios_multi_cpus=i386,x86_64 --test_output=errors
 }
 
 run_bazel

--- a/.kokoro
+++ b/.kokoro
@@ -64,7 +64,7 @@ run_bazel() {
     | cut -d'<' -f1)
 
   bazel clean
-  bazel test //... --xcode_version $xcode_version --ios_minimum_os=8.0 --ios_multi_cpus=i386,x86_64 --test_output=errors
+  bazel test //... --xcode_version $xcode_version --ios_minimum_os=8.0 --ios_multi_cpus=i386,x86_64 --test_output=all
 }
 
 run_bazel

--- a/.kokoro
+++ b/.kokoro
@@ -20,41 +20,7 @@ set -e
 # Display commands to stderr.
 set -x
 
-KOKORO_RUNNER_VERSION="v4.*"
 BAZEL_VERSION="0.20.0"
-
-# xcode-select's the provided xcode version.
-# Usage example:
-#     select_xcode 9.2.0
-select_xcode() {
-  desired_version="$1"
-  if [ -z "$desired_version" ]; then
-    return # No Xcode version to select.
-  fi
-
-  xcodes=$(ls /Applications/ | grep "Xcode")
-  for xcode_path in $xcodes; do
-    xcode_version=$(cat /Applications/$xcode_path/Contents/version.plist \
-      | grep "CFBundleShortVersionString" -A1 \
-      | grep string \
-      | cut -d'>' -f2 \
-      | cut -d'<' -f1)
-    xcode_version_as_number="$(version_as_number $xcode_version)"
-
-    if [ "$xcode_version_as_number" -ne "$(version_as_number $desired_version)" ]; then
-      continue
-    fi
-
-    sudo xcode-select --switch /Applications/$xcode_path/Contents/Developer
-    xcodebuild -version
-
-    # Resolves the following crash when switching Xcode versions:
-    # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
-    launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
-
-    break
-  done
-}
 
 fix_bazel_imports() {
   if [ -z "$KOKORO_BUILD_NUMBER" ]; then
@@ -82,8 +48,6 @@ run_bazel() {
     bazel version
     use_bazel.sh "$BAZEL_VERSION"
     bazel version
-
-    select_xcode "$XCODE_VERSION"
 
     # Move into our cloned repo
     cd github/repo


### PR DESCRIPTION
This logic is no longer necessary because kokoro is able to select the Xcode version directly.

Also removed the unused `KOKORO_RUNNER_VERSION` variable.