### PR TITLE
Adding Carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+.DS_Store

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>3.0.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/MotionInterchange.xcodeproj/project.pbxproj
+++ b/MotionInterchange.xcodeproj/project.pbxproj
@@ -1,0 +1,403 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		6DC6507322388CE7003DBBF5 /* MDMRepetitionTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6505F22388CE7003DBBF5 /* MDMRepetitionTraits.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6507422388CE7003DBBF5 /* MDMRepetitionOverTime.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6506022388CE7003DBBF5 /* MDMRepetitionOverTime.m */; };
+		6DC6507522388CE7003DBBF5 /* MDMMotionCurve.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6506122388CE7003DBBF5 /* MDMMotionCurve.m */; };
+		6DC6507622388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6506222388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.m */; };
+		6DC6507722388CE7003DBBF5 /* MotionInterchange.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506322388CE7003DBBF5 /* MotionInterchange.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6507822388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6506422388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.m */; };
+		6DC6507922388CE7003DBBF5 /* MDMSubclassingRestricted.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506522388CE7003DBBF5 /* MDMSubclassingRestricted.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6507A22388CE7003DBBF5 /* MDMRepetition.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6506622388CE7003DBBF5 /* MDMRepetition.m */; };
+		6DC6507B22388CE7003DBBF5 /* MDMAnimationTraits.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6506722388CE7003DBBF5 /* MDMAnimationTraits.m */; };
+		6DC6507C22388CE7003DBBF5 /* MDMSpringTimingCurve.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DC6506822388CE7003DBBF5 /* MDMSpringTimingCurve.m */; };
+		6DC6507D22388CE7003DBBF5 /* MDMMotionTiming.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506922388CE7003DBBF5 /* MDMMotionTiming.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6507E22388CE7003DBBF5 /* MDMRepetitionOverTime.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506A22388CE7003DBBF5 /* MDMRepetitionOverTime.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6507F22388CE7003DBBF5 /* MDMMotionCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506B22388CE7003DBBF5 /* MDMMotionCurve.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6508022388CE7003DBBF5 /* MDMTimingCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506C22388CE7003DBBF5 /* MDMTimingCurve.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6508122388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506D22388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6508222388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506E22388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6508322388CE7003DBBF5 /* MDMSpringTimingCurve.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6506F22388CE7003DBBF5 /* MDMSpringTimingCurve.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6508422388CE7003DBBF5 /* MDMAnimationTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6507022388CE7003DBBF5 /* MDMAnimationTraits.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6508522388CE7003DBBF5 /* MDMRepetition.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6507122388CE7003DBBF5 /* MDMRepetition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6DC6508622388CE7003DBBF5 /* MDMMotionRepetition.h in Headers */ = {isa = PBXBuildFile; fileRef = 6DC6507222388CE7003DBBF5 /* MDMMotionRepetition.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		6DC6505322388CA7003DBBF5 /* MotionInterchange.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MotionInterchange.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6DC6505F22388CE7003DBBF5 /* MDMRepetitionTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMRepetitionTraits.h; sourceTree = "<group>"; };
+		6DC6506022388CE7003DBBF5 /* MDMRepetitionOverTime.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMRepetitionOverTime.m; sourceTree = "<group>"; };
+		6DC6506122388CE7003DBBF5 /* MDMMotionCurve.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMMotionCurve.m; sourceTree = "<group>"; };
+		6DC6506222388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CAMediaTimingFunction+MDMTimingCurve.m"; sourceTree = "<group>"; };
+		6DC6506322388CE7003DBBF5 /* MotionInterchange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MotionInterchange.h; sourceTree = "<group>"; };
+		6DC6506422388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMSpringTimingCurveGenerator.m; sourceTree = "<group>"; };
+		6DC6506522388CE7003DBBF5 /* MDMSubclassingRestricted.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMSubclassingRestricted.h; sourceTree = "<group>"; };
+		6DC6506622388CE7003DBBF5 /* MDMRepetition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMRepetition.m; sourceTree = "<group>"; };
+		6DC6506722388CE7003DBBF5 /* MDMAnimationTraits.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMAnimationTraits.m; sourceTree = "<group>"; };
+		6DC6506822388CE7003DBBF5 /* MDMSpringTimingCurve.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDMSpringTimingCurve.m; sourceTree = "<group>"; };
+		6DC6506922388CE7003DBBF5 /* MDMMotionTiming.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMMotionTiming.h; sourceTree = "<group>"; };
+		6DC6506A22388CE7003DBBF5 /* MDMRepetitionOverTime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMRepetitionOverTime.h; sourceTree = "<group>"; };
+		6DC6506B22388CE7003DBBF5 /* MDMMotionCurve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMMotionCurve.h; sourceTree = "<group>"; };
+		6DC6506C22388CE7003DBBF5 /* MDMTimingCurve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMTimingCurve.h; sourceTree = "<group>"; };
+		6DC6506D22388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMSpringTimingCurveGenerator.h; sourceTree = "<group>"; };
+		6DC6506E22388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "CAMediaTimingFunction+MDMTimingCurve.h"; sourceTree = "<group>"; };
+		6DC6506F22388CE7003DBBF5 /* MDMSpringTimingCurve.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMSpringTimingCurve.h; sourceTree = "<group>"; };
+		6DC6507022388CE7003DBBF5 /* MDMAnimationTraits.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMAnimationTraits.h; sourceTree = "<group>"; };
+		6DC6507122388CE7003DBBF5 /* MDMRepetition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMRepetition.h; sourceTree = "<group>"; };
+		6DC6507222388CE7003DBBF5 /* MDMMotionRepetition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDMMotionRepetition.h; sourceTree = "<group>"; };
+		6DC6508722388CFA003DBBF5 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6DC6505022388CA7003DBBF5 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6DC6504922388CA7003DBBF5 = {
+			isa = PBXGroup;
+			children = (
+				6DC6505E22388CE7003DBBF5 /* src */,
+				6DC6505422388CA7003DBBF5 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6DC6505422388CA7003DBBF5 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6DC6505322388CA7003DBBF5 /* MotionInterchange.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6DC6505E22388CE7003DBBF5 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				6DC6508722388CFA003DBBF5 /* Info.plist */,
+				6DC6506E22388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.h */,
+				6DC6506222388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.m */,
+				6DC6507022388CE7003DBBF5 /* MDMAnimationTraits.h */,
+				6DC6506722388CE7003DBBF5 /* MDMAnimationTraits.m */,
+				6DC6506B22388CE7003DBBF5 /* MDMMotionCurve.h */,
+				6DC6506122388CE7003DBBF5 /* MDMMotionCurve.m */,
+				6DC6507222388CE7003DBBF5 /* MDMMotionRepetition.h */,
+				6DC6506922388CE7003DBBF5 /* MDMMotionTiming.h */,
+				6DC6507122388CE7003DBBF5 /* MDMRepetition.h */,
+				6DC6506622388CE7003DBBF5 /* MDMRepetition.m */,
+				6DC6506A22388CE7003DBBF5 /* MDMRepetitionOverTime.h */,
+				6DC6506022388CE7003DBBF5 /* MDMRepetitionOverTime.m */,
+				6DC6505F22388CE7003DBBF5 /* MDMRepetitionTraits.h */,
+				6DC6506F22388CE7003DBBF5 /* MDMSpringTimingCurve.h */,
+				6DC6506822388CE7003DBBF5 /* MDMSpringTimingCurve.m */,
+				6DC6506D22388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.h */,
+				6DC6506422388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.m */,
+				6DC6506522388CE7003DBBF5 /* MDMSubclassingRestricted.h */,
+				6DC6506C22388CE7003DBBF5 /* MDMTimingCurve.h */,
+				6DC6506322388CE7003DBBF5 /* MotionInterchange.h */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		6DC6504E22388CA7003DBBF5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DC6508322388CE7003DBBF5 /* MDMSpringTimingCurve.h in Headers */,
+				6DC6507322388CE7003DBBF5 /* MDMRepetitionTraits.h in Headers */,
+				6DC6508522388CE7003DBBF5 /* MDMRepetition.h in Headers */,
+				6DC6508022388CE7003DBBF5 /* MDMTimingCurve.h in Headers */,
+				6DC6508122388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.h in Headers */,
+				6DC6508622388CE7003DBBF5 /* MDMMotionRepetition.h in Headers */,
+				6DC6507F22388CE7003DBBF5 /* MDMMotionCurve.h in Headers */,
+				6DC6508222388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.h in Headers */,
+				6DC6507722388CE7003DBBF5 /* MotionInterchange.h in Headers */,
+				6DC6507922388CE7003DBBF5 /* MDMSubclassingRestricted.h in Headers */,
+				6DC6507E22388CE7003DBBF5 /* MDMRepetitionOverTime.h in Headers */,
+				6DC6507D22388CE7003DBBF5 /* MDMMotionTiming.h in Headers */,
+				6DC6508422388CE7003DBBF5 /* MDMAnimationTraits.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		6DC6505222388CA7003DBBF5 /* MotionInterchange */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6DC6505B22388CA7003DBBF5 /* Build configuration list for PBXNativeTarget "MotionInterchange" */;
+			buildPhases = (
+				6DC6504E22388CA7003DBBF5 /* Headers */,
+				6DC6504F22388CA7003DBBF5 /* Sources */,
+				6DC6505022388CA7003DBBF5 /* Frameworks */,
+				6DC6505122388CA7003DBBF5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MotionInterchange;
+			productName = MotionInterchange;
+			productReference = 6DC6505322388CA7003DBBF5 /* MotionInterchange.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6DC6504A22388CA7003DBBF5 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1010;
+				ORGANIZATIONNAME = "The Material Motion Authors";
+				TargetAttributes = {
+					6DC6505222388CA7003DBBF5 = {
+						CreatedOnToolsVersion = 10.1;
+					};
+				};
+			};
+			buildConfigurationList = 6DC6504D22388CA7003DBBF5 /* Build configuration list for PBXProject "MotionInterchange" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 6DC6504922388CA7003DBBF5;
+			productRefGroup = 6DC6505422388CA7003DBBF5 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6DC6505222388CA7003DBBF5 /* MotionInterchange */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		6DC6505122388CA7003DBBF5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6DC6504F22388CA7003DBBF5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6DC6507B22388CE7003DBBF5 /* MDMAnimationTraits.m in Sources */,
+				6DC6507522388CE7003DBBF5 /* MDMMotionCurve.m in Sources */,
+				6DC6507422388CE7003DBBF5 /* MDMRepetitionOverTime.m in Sources */,
+				6DC6507C22388CE7003DBBF5 /* MDMSpringTimingCurve.m in Sources */,
+				6DC6507622388CE7003DBBF5 /* CAMediaTimingFunction+MDMTimingCurve.m in Sources */,
+				6DC6507822388CE7003DBBF5 /* MDMSpringTimingCurveGenerator.m in Sources */,
+				6DC6507A22388CE7003DBBF5 /* MDMRepetition.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6DC6505922388CA7003DBBF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		6DC6505A22388CA7003DBBF5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		6DC6505C22388CA7003DBBF5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.material-motion.MotionInterchange";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6DC6505D22388CA7003DBBF5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.material-motion.MotionInterchange";
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6DC6504D22388CA7003DBBF5 /* Build configuration list for PBXProject "MotionInterchange" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DC6505922388CA7003DBBF5 /* Debug */,
+				6DC6505A22388CA7003DBBF5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6DC6505B22388CA7003DBBF5 /* Build configuration list for PBXNativeTarget "MotionInterchange" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DC6505C22388CA7003DBBF5 /* Debug */,
+				6DC6505D22388CA7003DBBF5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6DC6504A22388CA7003DBBF5 /* Project object */;
+}

--- a/MotionInterchange.xcodeproj/xcshareddata/xcschemes/MotionInterchange.xcscheme
+++ b/MotionInterchange.xcodeproj/xcshareddata/xcschemes/MotionInterchange.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6DC6505222388CA7003DBBF5"
+               BuildableName = "MotionInterchange.framework"
+               BlueprintName = "MotionInterchange"
+               ReferencedContainer = "container:MotionInterchange.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6DC6505222388CA7003DBBF5"
+            BuildableName = "MotionInterchange.framework"
+            BlueprintName = "MotionInterchange"
+            ReferencedContainer = "container:MotionInterchange.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "6DC6505222388CA7003DBBF5"
+            BuildableName = "MotionInterchange.framework"
+            BlueprintName = "MotionInterchange"
+            ReferencedContainer = "container:MotionInterchange.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Adding Carthage support by creating `MotionInterchange.framework` target with it's scheme share so that Carthage is able to find an build it's shared scheme according to what is defined in the scheme.

 By correctly exposing the public headers and hiding the private headers, this will also tell Xcode to build and include the correct headers available to library consumers.